### PR TITLE
suggested changes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,8 @@ include = [
     "Cargo.toml",
 ]
 
+edition = "2018"
+
 [badges]
 travis-ci = { repository = "dns2utf8/drop_guard", branch = "master" }
 appveyor = { repository = "dns2utf8/drop-guard", branch = "master", service = "github" }

--- a/examples/rainbow.rs
+++ b/examples/rainbow.rs
@@ -4,10 +4,12 @@ use drop_guard::DropGuard;
 
 fn main() {
     let s = String::from("a commonString");
-    let mut s = DropGuard::new(s, |final_string| println!("s became {} at last", final_string));
-    
+    let mut s = DropGuard::new(s, |final_string| {
+        println!("s became {} at last", final_string)
+    });
+
     // much code and time passes by ...
     *s = "a rainbow".to_string();
-    
+
     // by the end of this function the String will have become a rainbow
 }

--- a/examples/thread.rs
+++ b/examples/thread.rs
@@ -2,16 +2,18 @@ extern crate drop_guard;
 
 use drop_guard::DropGuard;
 
-use std::thread::{spawn, sleep};
+use std::thread::{sleep, spawn};
 use std::time::Duration;
 
 fn main() {
     // The guard must have a name. _ will drop it instantly, which would lead to unexpected results
-    let _g = DropGuard::new(spawn(move || {
-                            sleep(Duration::from_secs(2));
-                            println!("println! from thread");
-                        })
-                        , |join_handle| join_handle.join().unwrap());
-    
+    let _g = DropGuard::new(
+        spawn(move || {
+            sleep(Duration::from_secs(2));
+            println!("println! from thread");
+        }),
+        |join_handle| join_handle.join().unwrap(),
+    );
+
     println!("Waiting for thread ...");
 }

--- a/examples/threadpool.rs
+++ b/examples/threadpool.rs
@@ -7,10 +7,10 @@ use threadpool::ThreadPool;
 fn main() {
     let pool = ThreadPool::new(4);
     let pool = DropGuard::new(pool, |pool| pool.join());
-    
+
     for i in 0..8 {
         pool.execute(move || print!("{} ", i));
     }
-    
+
     println!("Waiting for threads ...");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,6 @@
 //! ```
 //!
 
-use std::boxed::Box;
 use std::ops::{Deref, DerefMut, Drop, FnMut};
 
 /// The DropGuard will remain to `Send` and `Sync` from `T`.
@@ -52,7 +51,7 @@ use std::ops::{Deref, DerefMut, Drop, FnMut};
 /// ```
 pub struct DropGuard<T, F: FnMut(T)> {
     data: Option<T>,
-    func: Box<F>,
+    func: F,
 }
 
 impl<T: Sized, F: FnMut(T)> DropGuard<T, F> {
@@ -72,7 +71,7 @@ impl<T: Sized, F: FnMut(T)> DropGuard<T, F> {
     pub fn new(data: T, func: F) -> DropGuard<T, F> {
         DropGuard {
             data: Some(data),
-            func: Box::new(func),
+            func: func,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 //!
 //! # Example:
 //!
-//! ```
+//! ```no_run
 //! extern crate drop_guard;
 //!
 //! use drop_guard::DropGuard;
@@ -20,7 +20,7 @@
 //!                             println!("println! from thread");
 //!                         })
 //!                         , |join_handle| join_handle.join().unwrap());
-//!     
+//!
 //!     println!("Waiting for thread ...");
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -76,6 +76,10 @@ impl<T: Sized, F: FnOnce(T)> DropGuard<T, F> {
             func: Some(func),
         }
     }
+
+    pub fn into_inner(mut self) -> T {
+        self.data.take().expect("the data is here until the drop")
+    }
 }
 
 /// Use the captured value.
@@ -127,8 +131,8 @@ impl<T, F: FnOnce(T)> DerefMut for DropGuard<T, F> {
 /// ```
 impl<T, F: FnOnce(T)> Drop for DropGuard<T, F> {
     fn drop(&mut self) {
-        let data = self.data.take().expect("the data is here until the drop");
-        let f = self.func.take().expect("the func is here until the drop");
-        f(data);
+        if let (Some(data), Some(f)) = (self.data.take(), self.func.take()) {
+            f(data);
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,9 @@
 //! ```
 //!
 
-use std::ops::{Deref, DerefMut};
+#![no_std]
+
+use core::ops::{Deref, DerefMut};
 
 /// The DropGuard will remain to `Send` and `Sync` from `T`.
 ///
@@ -128,57 +130,5 @@ impl<T, F: FnOnce(T)> Drop for DropGuard<T, F> {
         let data = self.data.take().expect("the data is here until the drop");
         let f = self.func.take().expect("the func is here until the drop");
         f(data);
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::sync::atomic::{AtomicUsize, Ordering};
-    use std::sync::Arc;
-
-    #[test]
-    fn it_works() {
-        let mut i = 0;
-        {
-            let _ = DropGuard::new(0, |_| i = 42);
-        }
-        assert_eq!(42, i);
-    }
-
-    #[test]
-    fn deref() {
-        let g = DropGuard::new(5usize, |_| {});
-        assert_eq!(5usize, *g);
-    }
-
-    #[test]
-    fn deref_mut() {
-        let mut g = DropGuard::new(5usize, |_| {});
-        *g = 12;
-        assert_eq!(12usize, *g);
-    }
-
-    #[test]
-    fn drop_change() {
-        let a = Arc::new(AtomicUsize::new(9));
-        {
-            let _ = DropGuard::new(a.clone(), |i| i.store(42, Ordering::Relaxed));
-        }
-        assert_eq!(42usize, a.load(Ordering::Relaxed));
-    }
-
-    #[test]
-    fn keep_sync_shared_data() {
-        fn assert_sync<T: Sync>(_: T) {}
-        let g = DropGuard::new(vec![0], |_| {});
-        assert_sync(g);
-    }
-
-    #[test]
-    fn keep_send_shared_data() {
-        fn assert_send<T: Send>(_: T) {}
-        let g = DropGuard::new(vec![0], |_| {});
-        assert_send(g);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,17 +1,17 @@
 //! This crate gives a generic way to add a callback to any dropping value
-//! 
+//!
 //! You may use this for debugging values, see the [struct documentation](struct.DropGuard.html) or the [standalone examples](https://github.com/dns2utf8/drop_guard/tree/master/examples).
-//! 
+//!
 //! # Example:
-//! 
+//!
 //! ```
 //! extern crate drop_guard;
-//! 
+//!
 //! use drop_guard::DropGuard;
-//! 
+//!
 //! use std::thread::{spawn, sleep};
 //! use std::time::Duration;
-//! 
+//!
 //! fn main() {
 //!     // The guard must have a name. `_` will drop it instantly, which would
 //!     // lead to unexpected results
@@ -24,11 +24,10 @@
 //!     println!("Waiting for thread ...");
 //! }
 //! ```
-//! 
+//!
 
-
-use std::ops::{Deref, DerefMut, Drop, FnMut};
 use std::boxed::Box;
+use std::ops::{Deref, DerefMut, Drop, FnMut};
 
 /// The DropGuard will remain to `Send` and `Sync` from `T`.
 ///
@@ -58,16 +57,16 @@ pub struct DropGuard<T, F: FnMut(T)> {
 
 impl<T: Sized, F: FnMut(T)> DropGuard<T, F> {
     /// Creates a new guard taking in your data and a function.
-    /// 
+    ///
     /// ```
     /// use drop_guard::DropGuard;
-    /// 
+    ///
     /// let s = String::from("a commonString");
     /// let mut s = DropGuard::new(s, |final_string| println!("s became {} at last", final_string));
-    /// 
+    ///
     /// // much code and time passes by ...
     /// *s = "a rainbow".to_string();
-    /// 
+    ///
     /// // by the end of this function the String will have become a rainbow
     /// ```
     pub fn new(data: T, func: F) -> DropGuard<T, F> {
@@ -77,7 +76,6 @@ impl<T: Sized, F: FnMut(T)> DropGuard<T, F> {
         }
     }
 }
-
 
 /// Use the captured value.
 ///
@@ -126,11 +124,11 @@ impl<T, F: FnMut(T)> DerefMut for DropGuard<T, F> {
 /// });
 /// assert_eq!(42, *val);
 /// ```
-impl<T,F: FnMut(T)> Drop for DropGuard<T, F> {
+impl<T, F: FnMut(T)> Drop for DropGuard<T, F> {
     fn drop(&mut self) {
         let mut data: Option<T> = None;
         std::mem::swap(&mut data, &mut self.data);
-        
+
         let ref mut f = self.func;
         f(data.expect("the data is here until the drop"));
     }
@@ -168,8 +166,7 @@ mod tests {
     fn drop_change() {
         let a = Arc::new(AtomicUsize::new(9));
         {
-            let _ = DropGuard::new(a.clone()
-                                , |i| i.store(42, Ordering::Relaxed));
+            let _ = DropGuard::new(a.clone(), |i| i.store(42, Ordering::Relaxed));
         }
         assert_eq!(42usize, a.load(Ordering::Relaxed));
     }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,51 @@
+extern crate drop_guard;
+
+use drop_guard::*;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+#[test]
+fn it_works() {
+    let mut i = 0;
+    {
+        let _ = DropGuard::new(0, |_| i = 42);
+    }
+    assert_eq!(42, i);
+}
+
+#[test]
+fn deref() {
+    let g = DropGuard::new(5usize, |_| {});
+    assert_eq!(5usize, *g);
+}
+
+#[test]
+fn deref_mut() {
+    let mut g = DropGuard::new(5usize, |_| {});
+    *g = 12;
+    assert_eq!(12usize, *g);
+}
+
+#[test]
+fn drop_change() {
+    let a = Arc::new(AtomicUsize::new(9));
+    {
+        let _ = DropGuard::new(a.clone(), |i| i.store(42, Ordering::Relaxed));
+    }
+    assert_eq!(42usize, a.load(Ordering::Relaxed));
+}
+
+#[test]
+fn keep_sync_shared_data() {
+    fn assert_sync<T: Sync>(_: T) {}
+    let g = DropGuard::new(vec![0], |_| {});
+    assert_sync(g);
+}
+
+#[test]
+fn keep_send_shared_data() {
+    fn assert_send<T: Send>(_: T) {}
+    let g = DropGuard::new(vec![0], |_| {});
+    assert_send(g);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -46,3 +46,17 @@ fn keep_send_shared_data() {
     let g = DropGuard::new(vec![0], |_| {});
     assert_send(g);
 }
+
+#[test]
+fn into_inner_cancels() {
+    let mut x = 1;
+    {
+        let _g = DropGuard::new((), |_| x += 1);
+    }
+    assert_eq!(2, x);
+    {
+        let _g = DropGuard::new((), |_| x += 1);
+        _g.into_inner();
+    }
+    assert_eq!(2, x);
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,7 +1,4 @@
-extern crate drop_guard;
-
 use drop_guard::*;
-
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::Arc;
 


### PR DESCRIPTION
Apologies for a big PR with several commits. I would've split these into separate PRs, except that they depend on each other. This overlaps with some of what was discussed in https://github.com/dns2utf8/drop_guard/issues/3. I haven't made anything `unsafe`, though, since that's a bigger decision for the crate.

That said, is it possible this crate should be deprecated in favor of https://crates.io/crates/scopeguard? If so, maybe it would be appropriate to put a link in the README or something like that.